### PR TITLE
Add a scramble key for U2F transports

### DIFF
--- a/src/renderer/components/App.js
+++ b/src/renderer/components/App.js
@@ -457,6 +457,7 @@ export default () => {
             type: "command",
             text: `${selectedCommand.id} completed in ${delta}.`
           });
+          transport.setScrambleKey(scrambleKey);
         },
         error: error => {
           setCommandSub(null);

--- a/src/renderer/components/App.js
+++ b/src/renderer/components/App.js
@@ -16,6 +16,7 @@ import { listen } from "@ledgerhq/logs";
 import { open, disconnect } from "@ledgerhq/live-common/lib/hw";
 import { logs as socketLogs } from "@ledgerhq/live-common/lib/api/socket";
 import { commands } from "../commands";
+import AsciiField from './fields/AsciiField';
 import {
   execCommand,
   getDefaultValue,
@@ -155,6 +156,9 @@ const transportLabels = {
   "proxy@ws://localhost:8435": "proxy ws://localhost:8435"
 };
 
+const isTransportScrambleable = (name: string) =>
+  ['u2f', 'webauthn'].indexOf(name) > -1;
+
 if (typeof ledgerHidTransport === "undefined") {
   delete transportLabels.hid;
 }
@@ -268,6 +272,7 @@ export default () => {
   const [transportMode, setTransportMode] = useState(
     localStorage.getItem(LS_PREF_TRANSPORT) || "webble"
   );
+  const [scrambleKey, setScrambleKey] = useState('');
   const [transportOpening, setTransportOpening] = useState(false);
   const [advanced, setAdvanced] = useState(false);
   const [selectedCommand, setSelectedCommand] = useState(null);
@@ -566,11 +571,25 @@ export default () => {
                   />
                 </SectionRow>
               ) : (
-                <SectionRow>
-                  <div style={{ flex: 1 }}>Transport connected!</div>
-                  <SendButton secondary title="X" onClick={onLeaveTransport} />
-                  <SendButton red title="Close" onClick={onClose} />
-                </SectionRow>
+                <React.Fragment>
+                  <SectionRow>
+                    <div style={{ flex: 1 }}>Transport connected!</div>
+                    <SendButton secondary title="X" onClick={onLeaveTransport} />
+                    <SendButton red title="Close" onClick={onClose} />
+                  </SectionRow>
+                  {isTransportScrambleable(transportMode) && (
+                    <SectionRow>
+                      <AsciiField
+                        value={scrambleKey}
+                        onChange={value => {
+                          transport.setScrambleKey(value);
+                          setScrambleKey(value);
+                        }}
+                        placeholder="Scramble key"
+                      />
+                    </SectionRow>
+                  )}
+                </React.Fragment>
               )}
             </Section>
             <Separator />

--- a/src/renderer/components/fields/AsciiField.js
+++ b/src/renderer/components/fields/AsciiField.js
@@ -23,16 +23,18 @@ export type DataTypeAscii = {
 type Props = {
   value: string,
   onChange: string => void,
+  placeholder?: string,
   autoFocus?: boolean
 };
 
-const AsciiField = ({ value, onChange, autoFocus }: Props) => {
+const AsciiField = ({ value, onChange, placeholder, autoFocus }: Props) => {
   return (
     <Input
       type="text"
       value={value}
       onChange={e => onChange(e.target.value)}
       autoFocus={autoFocus}
+      placeholder={placeholder}
     />
   );
 };


### PR DESCRIPTION
> Closes #16

Adds the ability to set the scramble key for transports that support it (U2F, WebAuthn).

![2019-07-10_182332](https://user-images.githubusercontent.com/1671753/60986530-f3cbd600-a33f-11e9-95c6-f7018193c4ef.png)
